### PR TITLE
Fix for Single Car Spawning

### DIFF
--- a/InterchangeUnchained/Definition.json
+++ b/InterchangeUnchained/Definition.json
@@ -3,5 +3,5 @@
   "id": "Moloch.InterchangeUnchained",
   "name": "InterchangeUnchained Mod",
   "assemblies": [ "InterchangeUnchained" ],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
+++ b/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using Model.Database;
 using Model.OpsNew;
 using Serilog;
 using System;
@@ -6,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using Track;
+using UnityEngine;
 
 namespace InterchangeUnchained
 {
@@ -16,25 +19,47 @@ namespace InterchangeUnchained
         private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, MethodBase original)
         {
             var validInts = original.GetMethodBody().LocalVariables.Where(i => i.LocalType == typeof(int)).Select(s => s.LocalIndex).ToArray();
+            var validTrackSpans = original.GetMethodBody().LocalVariables.Where(i => i.LocalType == typeof(TrackSpan[])).Select(s => s.LocalIndex).ToArray();
+            var validPrefabStores = original.GetMethodBody().LocalVariables.Where(i => i.LocalType == typeof(IPrefabStore)).Select(s => s.LocalIndex).ToArray();
+
+            if(validTrackSpans.Length != 1 && validPrefabStores.Length != 1)
+            {
+                 throw new Exception("Could not find instructions to patch.");
+            }
+
             var logger = Log.ForContext(typeof(IndustryContext_AddOrderedCars_Patch));
             var codes = new List<CodeInstruction>(instructions);
 
-            for(int i = codes.Count -1; i >=0; i--)
+
+            for(int i = 0; i < codes.Count; i++)
             {
-                if (codes[i].opcode == OpCodes.Ldloc_S && codes[i].operand is LocalBuilder lb1 && validInts.Contains(lb1.LocalIndex)
-                    && codes[i + 1].opcode == OpCodes.Ldloc_S && codes[i + 1].operand is LocalBuilder lb2 && validInts.Contains(lb2.LocalIndex)
-                    && codes[i + 2].opcode == OpCodes.Blt)
+                if(//prefab
+                    codes[i].opcode == OpCodes.Stloc_S && codes[i].operand is LocalBuilder lb1 && validPrefabStores[0] == lb1.LocalIndex
+                    //num2
+                    && codes[i + 1].opcode == OpCodes.Ldc_I4_2
+                    && codes[i + 2].opcode  == OpCodes.Stloc_S && codes[i + 2].operand is LocalBuilder lb2 && validInts.Contains(lb2.LocalIndex)
+                    //num3
+                    && codes[i + 3].opcode == OpCodes.Ldc_I4_0
+                    && codes[i + 4].opcode == OpCodes.Stloc_S && codes[i + 4].operand is LocalBuilder lb3 && validInts.Contains(lb3.LocalIndex)
+                    //while
+                    && codes[i+5].opcode == OpCodes.Br)
                 {
-                    logger.Information("Found & replaced the code");
-                    logger.Information("Replacing {OpCode} {Operand} with a jump", codes[i + 2].opcode, codes[i + 2].operand.ToString());
-                    codes[i] = new CodeInstruction(OpCodes.Nop);
-                    codes[i + 1] = new CodeInstruction(OpCodes.Nop);
-                    codes[i+2] = new CodeInstruction(OpCodes.Br, codes[i+2].operand);
+                    logger.Information("Found Code Instruction");
+                    int index = i + 1;
+                    
+                    logger.Information("Removing variable assignment");
+                    codes.RemoveAt(index);
+                    
+                    logger.Information("Adding instructions to get number of Tracks to spawn");
+                    codes.Insert(index++, new CodeInstruction(OpCodes.Ldloc_S, validTrackSpans[0]));
+                    codes.Insert(index++, new CodeInstruction(OpCodes.Ldlen));
+                    codes.Insert(index++, new CodeInstruction(OpCodes.Conv_I4));
+
                     return codes.AsEnumerable();
                 }
             }
 
             throw new Exception("Could not find instructions to patch.");
-        }
+        }      
     }
 }

--- a/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
+++ b/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using Track;
-using UnityEngine;
 
 namespace InterchangeUnchained
 {

--- a/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
+++ b/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
@@ -29,7 +29,6 @@ namespace InterchangeUnchained
             var logger = Log.ForContext(typeof(IndustryContext_AddOrderedCars_Patch));
             var codes = new List<CodeInstruction>(instructions);
 
-
             for(int i = 0; i < codes.Count; i++)
             {
                 if(//prefab

--- a/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
+++ b/InterchangeUnchained/IndustryContext_AddOrderedCars_Patch.cs
@@ -29,7 +29,7 @@ namespace InterchangeUnchained
             var logger = Log.ForContext(typeof(IndustryContext_AddOrderedCars_Patch));
             var codes = new List<CodeInstruction>(instructions);
 
-            for(int i = 0; i < codes.Count; i++)
+            for(int i = 0; i < codes.Count - 5; i++)
             {
                 if(//prefab
                     codes[i].opcode == OpCodes.Stloc_S && codes[i].operand is LocalBuilder lb1 && validPrefabStores[0] == lb1.LocalIndex


### PR DESCRIPTION
Fixes an issue where single cars would spawn behind a previously spawned cut.

The old code logic continued looping until it tried to spawn only 1 car, rather than capping at the number of tracks to spawn on. New code logic caps the loop in this way.